### PR TITLE
Fix assets param typing in CoreClient.from_token

### DIFF
--- a/arkprts/client.py
+++ b/arkprts/client.py
@@ -112,7 +112,7 @@ class CoreClient:
         server: netn.ArknightsServer = "en",
         *,
         network: netn.NetworkSession | None = None,
-        assets: assetsn.Assets | None = None,
+        assets: assetsn.Assets | str | typing.Literal[False] | None = None,
     ) -> Self:
         """Create a client from a token."""
         auth = await authn.Auth.from_token(server, channel_uid, token, network=network)


### PR DESCRIPTION
I noticed that the typing for the `assets` param in `CoreClient.from_token` does not match that of the assets param in `CoreClient.__init__` while it's just passed to init as-is. This PR modifies the typing of `CoreClient.from_token` to allow the same input as `CoreClient.__init__`.