### PR TITLE
make logging use more consistent

### DIFF
--- a/arkprts/assets/git.py
+++ b/arkprts/assets/git.py
@@ -25,7 +25,7 @@ from . import base
 
 __all__ = ("GitAssets",)
 
-logger: logging.Logger = logging.getLogger("arkprts.assets.git")
+LOGGER: logging.Logger = logging.getLogger("arkprts.assets.git")
 
 GAMEDATA_REPOSITORY = "Kengxxiao/ArknightsGameData"
 TW_GAMEDATA_REPOSITORY = "aelurum/ArknightsGameData"  # zh-tw fork
@@ -98,25 +98,25 @@ async def download_repository(repository: str, destination: PathLike, allow: str
     commit_file = destination / "commit.txt"
 
     if not force and commit_file.exists() and time.time() - commit_file.stat().st_mtime < 60 * 60 * 6:
-        logger.debug("%s was updated recently, skipping download", repository)
+        LOGGER.debug("%s was updated recently, skipping download", repository)
         return
 
     try:
         commit = await get_github_repository_commit(repository)
     except aiohttp.ClientResponseError:
-        logger.warning("Failed to get %s commit, skipping download", repository, exc_info=True)
+        LOGGER.warning("Failed to get %s commit, skipping download", repository, exc_info=True)
         return
 
     if not force and commit_file.exists() and commit_file.read_text() == commit:
-        logger.debug("%s is up to date [%s]", repository, commit)
+        LOGGER.debug("%s is up to date [%s]", repository, commit)
         return
 
-    logger.info("Downloading %s to %s [%s]", repository, str(destination), commit)
+    LOGGER.info("Downloading %s to %s [%s]", repository, str(destination), commit)
     tarball_path = await download_github_tarball(repository, destination / f"{repository.split('/')[-1]}.tar.gz")
 
-    logger.debug("Decompressing %s", repository)
+    LOGGER.debug("Decompressing %s", repository)
     tarball_commit = decompress_tarball(tarball_path, destination, allow=allow)
-    logger.debug("Decompressed %s %s", repository, tarball_commit)
+    LOGGER.debug("Decompressed %s %s", repository, tarball_commit)
     if tarball_commit not in commit:
         raise RuntimeError(f"Tarball commit {tarball_commit} does not match github commit {commit}")
 
@@ -124,7 +124,7 @@ async def download_repository(repository: str, destination: PathLike, allow: str
     commit_file.write_text(commit)
     os.utime(commit_file, (time.time(), time.time()))
 
-    logger.info("Downloaded %s", repository)
+    LOGGER.info("Downloaded %s", repository)
 
 
 async def update_git_repository(repository: str, directory: PathLike) -> None:
@@ -132,7 +132,7 @@ async def update_git_repository(repository: str, directory: PathLike) -> None:
     directory = pathlib.Path(directory)
 
     if not (directory / ".git").exists():
-        logger.info("Initializing repository in %s", directory)
+        LOGGER.info("Initializing repository in %s", directory)
         directory.parent.mkdir(parents=True, exist_ok=True)
         proc = await asyncio.create_subprocess_exec(
             "git",
@@ -143,7 +143,7 @@ async def update_git_repository(repository: str, directory: PathLike) -> None:
         )
         await proc.wait()
     else:
-        logger.info("Updating %s in %s", repository, directory)
+        LOGGER.info("Updating %s in %s", repository, directory)
         proc = await asyncio.create_subprocess_exec("git", "pull", cwd=directory)
         await proc.wait()
 

--- a/arkprts/auth.py
+++ b/arkprts/auth.py
@@ -103,7 +103,7 @@ __all__ = [
     "YostarAuth",
 ]
 
-logger: logging.Logger = logging.getLogger("arkprts.auth")
+LOGGER: logging.Logger = logging.getLogger("arkprts.auth")
 
 RawAuthMapping = typing.TypedDict("RawAuthMapping", {"server": netn.ArknightsServer, "channel_uid": str, "token": str})
 
@@ -243,7 +243,7 @@ class Auth(abc.ABC, CoreAuth):
             raise errors.NotLoggedInError("Not logged in.")
 
         async with self.session as headers:
-            logger.debug("[UID: %s] Sending request #%s to %s.", self.uid, headers["seqnum"], endpoint)
+            LOGGER.debug("[UID: %s] Sending request #%s to %s.", self.uid, headers["seqnum"], endpoint)
             return await self.request("gs", endpoint, headers=headers, server=self.server, **kwargs)
 
     async def _get_u8_token(
@@ -252,7 +252,7 @@ class Auth(abc.ABC, CoreAuth):
         access_token: str,
     ) -> tuple[str, str]:
         """Get an arknights uid and u8 token from a channel uid and access token."""
-        logger.debug("Getting u8 token for %s.", channel_uid)
+        LOGGER.debug("Getting u8 token for %s.", channel_uid)
         channel_id = {"cn": "1", "bili": "2", "en": "3", "jp": "3", "kr": "3"}[self.server]
         if channel_id == "3":
             extension = {"uid": channel_uid, "token": access_token}
@@ -285,7 +285,7 @@ class Auth(abc.ABC, CoreAuth):
         u8_token: str,
     ) -> str:
         """Get a secret from an arknights uid and a u8 token."""
-        logger.debug("Getting session secret for %s.", uid)
+        LOGGER.debug("Getting session secret for %s.", uid)
         if not self.network.versions.get(self.server):
             await self.network.load_version_config(self.server)
 
@@ -310,7 +310,7 @@ class Auth(abc.ABC, CoreAuth):
         data = await self.request("gs", "account/login", json=body, headers=headers)
         secret = data["secret"]
         self.session.secret = secret
-        logger.info("Logged in with UID %s", uid)
+        LOGGER.info("Logged in with UID %s", uid)
         return secret
 
     @classmethod
@@ -372,7 +372,7 @@ class YostarAuth(Auth):
 
     async def _request_yostar_auth(self, email: str) -> None:
         """Request to log in with a yostar account."""
-        logger.debug("Sending code to %s.", email)
+        LOGGER.debug("Sending code to %s.", email)
         body = {"platform": "android", "account": email, "authlang": "en"}
         await self.request_passport("account/yostar_auth_request", json=body)
 
@@ -400,12 +400,12 @@ class YostarAuth(Auth):
             "deviceId": self.device_ids[0],
         }
         data = await self.request_passport("user/create", json=body)
-        logger.debug("Created guest account %s", data["uid"])
+        LOGGER.debug("Created guest account %s", data["uid"])
         return data["uid"], data["token"]
 
     async def _bind_nickname(self, nickname: str) -> None:
         """Bind a nickname. Required for new accounts."""
-        logger.debug("Binding nickname of %s to %r.", self.uid, nickname)
+        LOGGER.debug("Binding nickname of %s to %r.", self.uid, nickname)
         await self.auth_request("user/bindNickName", json={"nickName": nickname})
 
     async def login_with_token(self, channel_uid: str, yostar_token: str) -> None:
@@ -750,10 +750,10 @@ class MultiAuth(CoreAuth):
         if session is None:
             session = await self._create_new_session(server)
             self.sessions.append(session)
-            logger.debug("Created new session %s for server %s.", session.uid, server)
+            LOGGER.debug("Created new session %s for server %s.", session.uid, server)
 
         async with session as headers:
-            logger.debug(
+            LOGGER.debug(
                 "[GUEST UID: %s %s] Sending request #%s to %s.",
                 session.uid,
                 server,
@@ -845,7 +845,7 @@ class GuestAuth(MultiAuth):
         else:
             return None
 
-        logging.debug("Loading cached auth %s for %s.", auth["channel_uid"], auth["server"])
+        LOGGER.debug("Loading cached auth %s for %s.", auth["channel_uid"], auth["server"])
         try:
             auth = await Auth.from_token(server, auth["channel_uid"], auth["token"], network=self.network)
         except errors.BaseArkprtsError as e:

--- a/arkprts/client.py
+++ b/arkprts/client.py
@@ -112,7 +112,7 @@ class CoreClient:
         server: netn.ArknightsServer = "en",
         *,
         network: netn.NetworkSession | None = None,
-        assets: assetsn.Assets | None = None,
+        assets: assetsn.Assets | str | typing.Literal[False] | None = None,
     ) -> Self:
         """Create a client from a token."""
         auth = await authn.Auth.from_token(server, channel_uid, token, network=network)

--- a/arkprts/network.py
+++ b/arkprts/network.py
@@ -39,7 +39,7 @@ __all__ = [
     "NetworkSession",
 ]
 
-logger: logging.Logger = logging.getLogger("arkprts.auth")
+LOGGER: logging.Logger = logging.getLogger("arkprts.auth")
 
 # these are in no way official slugs, just my own naming
 
@@ -186,7 +186,7 @@ class NetworkSession:
             await asyncio.wait([asyncio.create_task(self.load_network_config(server)) for server in NETWORK_ROUTES])
             return
 
-        logger.debug("Loading network configuration for %s.", server)
+        LOGGER.debug("Loading network configuration for %s.", server)
         data = await self.request(NETWORK_ROUTES[server])  # type: ignore # custom domain
         content = json.loads(data["content"])
         self.domains[server].update(content["configs"][content["funcVer"]]["network"])
@@ -198,6 +198,6 @@ class NetworkSession:
             await asyncio.wait([asyncio.create_task(self.load_version_config(server)) for server in NETWORK_ROUTES])
             return
 
-        logger.debug("Loading version configuration for %s.", server)
+        LOGGER.debug("Loading version configuration for %s.", server)
         data = await self.request("hv", server=server)
         self.versions[server].update(data)


### PR DESCRIPTION
This PR makes all logger constants named `LOGGER` (instead of a 50/50 between `logger` and `LOGGER`), and fixes one occurrence where the root logger is used instead of the local logger.