### PR TITLE
fix: explicitly list pyproject.toml dynamic fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 name = "arkprts"
 requires-python = ">=3.9"
 version = "0.3.5"
+dynamic = [
+    "dependencies",
+    "description",
+    "license",
+    "optional-dependencies",
+    "readme",
+]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
This should make the pyproject.toml completely [spec](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/)-compliant. Currently, arkprts fails to install on poetry, but this fix should amend that.

(don't mind wacky commit history, I forgot to merge upstream before pushing my changes and trying to amend that afterwards made it goof up. pls squash)